### PR TITLE
Fix GraphQLRequest null handling

### DIFF
--- a/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
+++ b/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
@@ -32,13 +32,16 @@ public class GraphQLRequest {
   }
 
   public static GraphQLRequest fromObjectNode(ObjectNode objectNode) {
-    final String query = objectNode.get("query").asText();
-    final String operationName = objectNode.has("operationName")
-      ? objectNode.get("operationName").asText()
-      : null;
-    final Map<String, Object> variables = objectNode.has("variables")
-      ? mapper.convertValue(objectNode.get("variables"), variablesTypeRef)
-      : null;
+    final String query =
+      objectNode.hasNonNull("query") ? objectNode.get("query").asText() : null;
+    final String operationName =
+      objectNode.hasNonNull("operationName")
+        ? objectNode.get("operationName").asText()
+        : null;
+    final Map<String, Object> variables =
+      objectNode.hasNonNull("variables")
+        ? mapper.convertValue(objectNode.get("variables"), variablesTypeRef)
+        : null;
     return new GraphQLRequest(query, operationName, variables);
   }
 }

--- a/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
+++ b/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
@@ -32,8 +32,7 @@ public class GraphQLRequest {
   }
 
   public static GraphQLRequest fromObjectNode(ObjectNode objectNode) {
-    final String query =
-      objectNode.hasNonNull("query") ? objectNode.get("query").asText() : null;
+    final String query = objectNode.path("query").textValue();
     final String operationName =
       objectNode.hasNonNull("operationName")
         ? objectNode.get("operationName").asText()

--- a/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
+++ b/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
@@ -33,6 +33,9 @@ public class GraphQLRequest {
 
   public static GraphQLRequest fromObjectNode(ObjectNode objectNode) {
     final String query = objectNode.path("query").textValue();
+    if (query == null || query.isBlank()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing field \"query\"");
+    }
     final String operationName =
       objectNode.hasNonNull("operationName")
         ? objectNode.get("operationName").asText()

--- a/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
+++ b/src/main/java/dev/sanda/apifi/dto/GraphQLRequest.java
@@ -40,7 +40,7 @@ public class GraphQLRequest {
     final Map<String, Object> variables =
       objectNode.hasNonNull("variables")
         ? mapper.convertValue(objectNode.get("variables"), variablesTypeRef)
-        : null;
+        : Collections.emptyMap();
     return new GraphQLRequest(query, operationName, variables);
   }
 }


### PR DESCRIPTION
## Summary
- avoid NPE when GraphQLRequest is built from JSON

## Testing
- `mvn -q -DskipTests=false test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:2.6 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_686be9804dfc8332bfaf4f7f16d18dec